### PR TITLE
Update PokemonSwitch Blender40.py, Quick fix for Blender 4.1.0

### DIFF
--- a/PokemonSwitch Blender40.py
+++ b/PokemonSwitch Blender40.py
@@ -2410,7 +2410,7 @@ def from_trmdlsv(filep, trmdl, rare, loadlods, bonestructh):
                                             uv4_layer.data[loop_idx].uv = uv4_array[vert_idx]
 
                                 #normals
-                                new_object.data.use_auto_smooth = True
+                                #new_object.data.use_auto_smooth = True
                                 new_object.data.normals_split_custom_set_from_vertices(normal_array)
                                 # add object to scene collection
                                 new_collection.objects.link(new_object)


### PR DESCRIPTION
Blender 4.1.0 don't have auto smooth anymore which cause the script to give a error when trying to import anything, this should remove the error for now.